### PR TITLE
Allow gitlab baseurl in env

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -1,3 +1,4 @@
 SALT=ExampleSalt
 GITHUB_TOKEN="token with repo permissions https://github.com/settings/tokens"
 GITLAB_TOKEN="token with permissions https://gitlab.com/-/profile/personal_access_tokens"
+BASE_GITLAB_API_URL=https://gitlab.mycompanyaddress.net/api/v4

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Does the same as [codersrank-org/repo_info_extractor](https://github.com/codersr
 $env:SALT="Optional PJSalt"
 $env:GITHUB_TOKEN="token with repo permisson https://github.com/settings/tokens"
 $env:GITLAB_TOKEN="token with permissions https://gitlab.com/-/profile/personal_access_tokens"
+$env:BASE_GITLAB_API_URL="url of the api endpoint for your gitlab instance: https://gitlab.mycompanyaddress.net/api/v4"
 ```
 
 Bash

--- a/README.md
+++ b/README.md
@@ -4,13 +4,15 @@ Does the same as [codersrank-org/repo_info_extractor](https://github.com/codersr
 
 ## Usage
 
+**REQUIRED**: Node v12 (does not work with most recent versions)
+
 ### Setup env options
 
 ```powershell
 $env:SALT="Optional PJSalt"
 $env:GITHUB_TOKEN="token with repo permisson https://github.com/settings/tokens"
 $env:GITLAB_TOKEN="token with permissions https://gitlab.com/-/profile/personal_access_tokens"
-$env:BASE_GITLAB_API_URL="url of the api endpoint for your gitlab instance: https://gitlab.mycompanyaddress.net/api/v4"
+$env:BASE_GITLAB_API_URL="defaults to public instance; url of self-hosted gitlab instance: https://gitlab.company.net/api/v4"
 ```
 
 Bash
@@ -19,6 +21,7 @@ Bash
 export SALT="Optional PJSalt"
 export GITHUB_TOKEN="token with repo permisson https://github.com/settings/tokens"
 export GITLAB_TOKEN="token with permissions https://gitlab.com/-/profile/personal_access_tokens"
+export BASE_GITLAB_API_URL="defaults to public instance; url of self-hosted gitlab instance: https://gitlab.company.net/api/v4"
 ```
 
 ### Run

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -9,6 +9,7 @@ export const env = {
 
   gitlab: {
     token: process.env.GITLAB_TOKEN,
+    base_url: process.env.BASE_GITLAB_API_URL,
   },
 
   salt: `${process.env.SALT}`,

--- a/src/services/providers/gitlab.ts
+++ b/src/services/providers/gitlab.ts
@@ -3,7 +3,7 @@ import { env } from '../../config/env'
 import { Repo } from '../../models/repo'
 
 const gitlab = axios.create({
-  baseURL: 'https://gitlab.com/api/v4',
+  baseURL: (env.gitlab.base_url || 'https://gitlab.com/api/v4'),
   headers: {
     authorization: `Bearer ${env.gitlab.token}`,
   },


### PR DESCRIPTION
This PR includes a new variable that can be set in the .env file that supports private gitlab instances that big companies normally use.